### PR TITLE
[osx] - add missing linkage to CoreVideo.framework

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,10 @@ set(SHADERTOY_SOURCES src/lodepng.cpp
 
 set(DEPLIBS ${OPENGL_LIBRARIES} ${GLEW_LIBRARIES} kissfft)
 
+if(APPLE)
+  set(DEPLIBS ${DEPLIBS} "-framework CoreVideo")
+endif()
+
 add_options(CXX ALL_BUILDS -std=c++11)
 
 build_addon(visualization.shadertoy SHADERTOY DEPLIBS)


### PR DESCRIPTION
as the title says ...

Also @notspiff or @wsnipex - the FindGLEW.cmake doesn't look in our depends prefix for glew atm in kodi master. I guess this is because there are bits missing from https://github.com/xbmc/xbmc/pull/5329 - but i hardcoded it and with this PR shadertoy works (very cool!) on osx...