### PR TITLE
Fix OpenGLES 2.0 usage

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,6 +33,11 @@
 #define AUDIO_BUFFER (1024)
 #define NUM_BANDS (AUDIO_BUFFER / 2)
 
+// Override GL_RED if not present with GL_LUMINANCE, e.g. on Android GLES
+#ifndef GL_RED
+#define GL_RED GL_LUMINANCE
+#endif
+
 struct Preset
 {
   std::string name;

--- a/visualization.shadertoy/addon.xml.in
+++ b/visualization.shadertoy/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="visualization.shadertoy"
-  version="1.2.0"
+  version="1.2.1"
   name="Shadertoy"
   provider-name="Team Kodi">
   <requires>@ADDON_DEPENDS@</requires>


### PR DESCRIPTION
Related to https://github.com/xbmc/visualization.shadertoy/issues/45

Seen also by test here https://github.com/xbmc/visualization.shadertoy/pull/44 and was gone down a bit top add here, Sorry.

Also noticed here https://github.com/xbmc/visualization.shadertoy/pull/44, just forgot that also Leia is affected.