### PR TITLE
Clamp framebuffer texture to avoid edge pixels bleeding

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -636,6 +636,8 @@ void CVisualizationShadertoy::LoadPreset(const std::string& shaderPath)
   glGenTextures(1, &m_state.framebuffer_texture);
   glBindTexture(GL_TEXTURE_2D, m_state.framebuffer_texture);
   glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, m_state.fbwidth, m_state.fbheight, 0, GL_RGB, GL_UNSIGNED_BYTE, 0);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
   glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
   glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 


### PR DESCRIPTION
Avoids wrap like white line at top of fire shader