### PR TITLE
[Nexus] initial release change for new Kodi 20 Nexus version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(version: "Matrix")
+buildPlugin(version: "Nexus")

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 This is a [Kodi](https://kodi.tv) visualization addon.
 
 [![License: GPL-2.0-or-later](https://img.shields.io/badge/License-GPL%20v2+-blue.svg)](LICENSE.md)
-[![Build Status](https://dev.azure.com/teamkodi/binary-addons/_apis/build/status/xbmc.visualization.shadertoy?branchName=Matrix)](https://dev.azure.com/teamkodi/binary-addons/_build/latest?definitionId=34&branchName=Matrix)
-[![Build Status](https://jenkins.kodi.tv/view/Addons/job/xbmc/job/visualization.shadertoy/job/Matrix/badge/icon)](https://jenkins.kodi.tv/blue/organizations/jenkins/xbmc%2Fvisualization.shadertoy/branches/)
-<!--- [![Build Status](https://ci.appveyor.com/api/projects/status/github/xbmc/visualization.shadertoy?branch=Matrix&svg=true)](https://ci.appveyor.com/project/xbmc/visualization-shadertoy?branch=Matrix) -->
+[![Build Status](https://dev.azure.com/teamkodi/binary-addons/_apis/build/status/xbmc.visualization.shadertoy?branchName=Nexus)](https://dev.azure.com/teamkodi/binary-addons/_build/latest?definitionId=34&branchName=Nexus)
+[![Build Status](https://jenkins.kodi.tv/view/Addons/job/xbmc/job/visualization.shadertoy/job/Nexus/badge/icon)](https://jenkins.kodi.tv/blue/organizations/jenkins/xbmc%2Fvisualization.shadertoy/branches/)
+<!--- [![Build Status](https://ci.appveyor.com/api/projects/status/github/xbmc/visualization.shadertoy?branch=Nexus&svg=true)](https://ci.appveyor.com/project/xbmc/visualization-shadertoy?branch=Nexus) -->
 
-![screenshot](https://raw.githubusercontent.com/xbmc/visualization.shadertoy/Matrix/visualization.shadertoy/resources/screenshot-01.jpg)
+![screenshot](https://raw.githubusercontent.com/xbmc/visualization.shadertoy/Nexus/visualization.shadertoy/resources/screenshot-01.jpg)
 
 ## Build instructions
 
@@ -21,7 +21,7 @@ The following instructions assume you will have built Kodi already in the `kodi-
 suggested by the README.
 
 1. `git clone --branch master https://github.com/xbmc/xbmc.git`
-2. `git clone --branch Matrix https://github.com/xbmc/visualization.shadertoy.git`
+2. `git clone --branch Nexus https://github.com/xbmc/visualization.shadertoy.git`
 3. `cd visualization.shadertoy && mkdir build && cd build`
 4. `cmake -DADDONS_TO_BUILD=visualization.shadertoy -DADDON_SRC_PREFIX=../.. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=../../xbmc/kodi-build/addons -DPACKAGE_ZIP=1 ../../xbmc/cmake/addons`
 5. `make`

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,7 @@ variables:
 trigger:
   branches:
     include:
-    - Matrix
+    - Nexus
     - releases/*
   paths:
     include:

--- a/visualization.shadertoy/addon.xml.in
+++ b/visualization.shadertoy/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="visualization.shadertoy"
-  version="2.3.0"
+  version="20.0.0"
   name="Shadertoy"
   provider-name="Team Kodi">
   <requires>@ADDON_DEPENDS@</requires>

--- a/visualization.shadertoy/changelog.txt
+++ b/visualization.shadertoy/changelog.txt
@@ -1,3 +1,12 @@
+[B]20.0.0[/B]
+- Change test builds to 'Kodi 20 Nexus'
+- Increase version to 20.0.0
+  - With start of Kodi 20 Nexus, takes addon as major the same version number as Kodi.
+    This done to know easier to which Kodi the addon works.
+- Prepared for new language translation by [Weblate](https://weblate.org/de/)
+- Update depend kissfft to version 131.1.0 (16. Feb. 2021)
+- Update depend lodepng to version from 27 Jun. 2021
+
 [B]2.3.0[/B]
 - Matrix API change GUI API 5.15.0
 


### PR DESCRIPTION
This change the builds to Kodi Nexus.

Further is the version to 20.0.0 increased to have equal to Kodi and to see on which Version this addon works.