### PR TITLE
remove notes on addon summary and description

### DIFF
--- a/visualization.shadertoy/resources/language/resource.language.en_gb/strings.po
+++ b/visualization.shadertoy/resources/language/resource.language.en_gb/strings.po
@@ -16,14 +16,10 @@ msgstr ""
 "Language: en_GB\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#. Addon summary used on Kodi's addon list and on websites
-#: visualization.shadertoy/addon.xml.in
 msgctxt "Addon Summary"
 msgid "Visualizations from Shadertoy"
 msgstr ""
 
-#. Addon description used on Kodi's addon list and on websites
-#: visualization.shadertoy/addon.xml.in
 msgctxt "Addon Description"
 msgid "This music visualization is based on Shadertoy based GPU programs."
 msgstr ""


### PR DESCRIPTION
The automation script brings on strings.po by "Addon Summary" and "Addon Description"  a bit bad move, see https://github.com/xbmc/visualization.shadertoy/pull/77.

This removes this parts until fixed.
